### PR TITLE
Import based on compilation outputs

### DIFF
--- a/index-import.cpp
+++ b/index-import.cpp
@@ -24,7 +24,7 @@ using namespace clang;
 using namespace clang::index;
 using namespace clang::index::writer;
 
-static cl::list<std::string> PathRemaps("remap", cl::OneOrMore,
+static cl::list<std::string> PathRemaps("remap",
                                         cl::desc("Path remapping substitution"),
                                         cl::value_desc("regex=replacement"));
 static cl::alias PathRemapsAlias("r", cl::aliasopt(PathRemaps));

--- a/index-import.cpp
+++ b/index-import.cpp
@@ -32,7 +32,7 @@ static cl::alias PathRemapsAlias("r", cl::aliasopt(PathRemaps));
 static cl::list<std::string> InputIndexPaths(cl::Positional, cl::OneOrMore,
                                              cl::desc("<input-indexstores>"));
 
-static cl::list<std::string> RemapFilePaths("import-output-file", cl::OneOrMore,
+static cl::list<std::string> RemapFilePaths("import-output-file",
                                              cl::desc("import-output-file="));
 static cl::opt<std::string> OutputIndexPath(cl::Positional, cl::Required,
                                             cl::desc("<output-indexstore>"));
@@ -220,8 +220,7 @@ importUnit(StringRef outputUnitsPath, StringRef inputUnitPath,
   // Cloning records when we've got an output records path
   const auto cloneDepRecords = !outputRecordsPath.empty();
 
-  // TODO: verify incremental with cloneDepRecords
-  if (!cloneDepRecords && Incremental) {
+  if (Incremental) {
     // Check if the unit file is already up to date
     SmallString<256> remappedOutputFilePath;
     if (outputFile[0] != '/') {


### PR DESCRIPTION
This PR adds the capability to import output files from a compilation:
to improve performance and experiment with using a "global shared index"
while remote caching a subset for lib. The github issue has some overall
mentions of this https://github.com/bazelbuild/rules_swift/issues/561

Index while building is performant in clang and swift becauase it
conditionally writes data based on files in a global index cache reused
across all clang/swift invocations in the build. The overhead of 3-5%
performance hit in the whitepaper of "Index while building" seems hinged
on the fact it'd be using a global index cache.  With the per library
index as rules_swift implemented this feature, "Index while building"
adds a 300% increase in build times in my testing.

Longer term, can add flags to clang and swift indexing to be aware of
remote compilation and caching, this is a quick hack incase that doesn't
ever happen.

Remote build possibilities:

The plan is to be able to use a global index on compilation fix
compilation performance and minimize the O ( M imports * N modules )
disk usage. I'd then intend to use this code to import a subset of the
global index material into the remote cache by putting it in `bazel-out`
at `swift_library`'s "index-store" path. Eventually a feature can be
added to rules_cc following the same pattern for .m, .cpp

Local build possibilities:

I plan to import swift_library index cache hits from `bazel-out`
into Xcode's index.

However, importing output files as a capability is useful even if that
doesn't play out: if we orient index-import around output files, then it
doesn't have to enumerate and process an entire index ever again.
Another build related program ran aas an aspect or via BEP could read
outputs and then invoke index-import with these outputs.