### PR TITLE
Update for Swift 5.5

### DIFF
--- a/index-import.cpp
+++ b/index-import.cpp
@@ -48,13 +48,14 @@ static cl::opt<bool>
 
 struct Remapper {
 public:
-  std::string remap(const std::string &input) const {
+  std::string remap(const llvm::StringRef input) const {
+    std::string input_str = input.str();
     for (const auto &remap : this->_remaps) {
       const auto &pattern = std::get<std::regex>(remap);
       const auto &replacement = std::get<std::string>(remap);
 
       std::smatch match;
-      if (std::regex_search(input, match, pattern)) {
+      if (std::regex_search(input_str, match, pattern)) {
         // I haven't seen this design in other regex APIs, and is worth some
         // explanation. The replacement string is conceptually a format string.
         // The format() function takes no explicit arguments, instead it gets
@@ -65,7 +66,7 @@ public:
     }
 
     // No patterns matched, return the input unaltered.
-    return input;
+    return input_str;
   }
 
   void addRemap(const std::regex &pattern, const std::string &replacement) {
@@ -367,7 +368,7 @@ static std::string normalizePath(StringRef Path) {
     if (*I != ".")
       sys::path::append(NormalizedPath, *I);
   }
-  return NormalizedPath.str();
+  return NormalizedPath.str().str();
 }
 
 static bool remapIndex(const Remapper &remapper,

--- a/tests/clang/expected.txt
+++ b/tests/clang/expected.txt
@@ -1,19 +1,19 @@
 CHECK: ---
 CHECK: # output/v5/units/output.c.o-{{.+}}
 CHECK: WorkingDirectory: /fake/working/dir
-CHECK: MainFilePath: 
+CHECK: MainFilePath:
 CHECK: OutputFile: output.c.o
-CHECK: ModuleName: 
+CHECK: ModuleName:
 CHECK: IsSystemUnit: 0
 CHECK: IsModuleUnit: 0
 CHECK: IsDebugCompilation: 1
-CHECK: CompilationTarget: x86_64-apple-macosx10.{{.+}}
+CHECK: CompilationTarget: {{x86_64|arm64}}-apple-macosx10.{{.+}}
 CHECK: SysrootPath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.*}}.sdk
 CHECK: ProviderIdentifier: clang
 CHECK: ProviderVersion: {{.+}}
 CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
-CHECK: 	UnitOrRecordName: input.c-1GAVGMEKRGFCS
+CHECK: 	UnitOrRecordName: input.c-50XRP2AC092F
 CHECK: 	FilePath: input.c
-CHECK: 	ModuleName: 
+CHECK: 	ModuleName:

--- a/tests/multiple/expected.txt
+++ b/tests/multiple/expected.txt
@@ -1,38 +1,38 @@
 CHECK: ---
 CHECK: # output/v5/units/output1.c.o-{{.+}}
 CHECK: WorkingDirectory: /fake/working/dir
-CHECK: MainFilePath: 
+CHECK: MainFilePath:
 CHECK: OutputFile: output1.c.o
-CHECK: ModuleName: 
+CHECK: ModuleName:
 CHECK: IsSystemUnit: 0
 CHECK: IsModuleUnit: 0
 CHECK: IsDebugCompilation: 1
-CHECK: CompilationTarget: x86_64-apple-macosx10.{{.+}}
+CHECK: CompilationTarget: {{x86_64|arm64}}-apple-macosx10.{{.+}}
 CHECK: SysrootPath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.+}}.sdk
 CHECK: ProviderIdentifier: clang
 CHECK: ProviderVersion: {{.+}}
 CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
-CHECK: 	UnitOrRecordName: input1.c-25D1KZY099GN2
+CHECK: 	UnitOrRecordName: input1.c-H8E66JWPU5WU
 CHECK: 	FilePath: input1.c
-CHECK: 	ModuleName: 
+CHECK: 	ModuleName:
 CHECK: ---
 CHECK: # output/v5/units/output2.c.o-{{.+}}
 CHECK: WorkingDirectory: /fake/working/dir
-CHECK: MainFilePath: 
+CHECK: MainFilePath:
 CHECK: OutputFile: output2.c.o
-CHECK: ModuleName: 
+CHECK: ModuleName:
 CHECK: IsSystemUnit: 0
 CHECK: IsModuleUnit: 0
 CHECK: IsDebugCompilation: 1
-CHECK: CompilationTarget: x86_64-apple-macosx10.{{.+}}
+CHECK: CompilationTarget: {{x86_64|arm64}}-apple-macosx10.{{.+}}
 CHECK: SysrootPath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.+}}.sdk
 CHECK: ProviderIdentifier: clang
 CHECK: ProviderVersion: {{.+}}
 CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
-CHECK: 	UnitOrRecordName: input2.c-1F2N5TQ6O2TRL
+CHECK: 	UnitOrRecordName: input2.c-1UNY7PC9RPELF
 CHECK: 	FilePath: input2.c
-CHECK: 	ModuleName: 
+CHECK: 	ModuleName:

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 readonly base_dir=$(dirname "$0")
 
 clang() {
-    xcrun --sdk macosx clang "$@"
+    xcrun --sdk macosx clang -mmacosx-version-min=10.0.0 "$@"
 }
 
 ############################################################
@@ -30,7 +30,7 @@ clang -fsyntax-only -index-store-path input input.c
 
 # Check that the expected index files exist.
 ls output/v5/units/output.c.o-1I92L511L7IRP >/dev/null
-ls output/v5/records/CS/input.c-1GAVGMEKRGFCS >/dev/null
+ls output/v5/records/2F/input.c-50XRP2AC092F >/dev/null
 
 # Check that the record files are identical.
 diff -q -r {input,output}/v5/records/
@@ -47,7 +47,7 @@ pushd "$base_dir"/swiftc >/dev/null
 rm -fr input output
 
 # Produce the index and delete the unneeded .o.
-xcrun swiftc -index-store-path input -c input.swift && rm input.o
+xcrun swiftc -target "$(uname -m)-apple-macosx10.9.0" -index-store-path input -c input.swift && rm input.o
 
 ../../build/index-import \
   -remap input.o=output.o \
@@ -55,7 +55,7 @@ xcrun swiftc -index-store-path input -c input.swift && rm input.o
   input output
 
 # See https://llvm.org/docs/CommandGuide/FileCheck.html
-../../build/absolute-unit output/v5/units/* \
+../../build/absolute-unit output/v5/units/output* output/v5/units/*.swiftinterface* \
   | FileCheck expected.txt
 
 # Check that the expected index files exist.
@@ -93,8 +93,8 @@ clang -fsyntax-only -index-store-path input2 input2.c
 # Check that the expected index files exist.
 ls output/v5/units/output1.c.o-ZW8ISK3OCQ8L >/dev/null
 ls output/v5/units/output2.c.o-1ZBCL54RNWOPC >/dev/null
-ls output/v5/records/N2/input1.c-25D1KZY099GN2 >/dev/null
-ls output/v5/records/RL/input2.c-1F2N5TQ6O2TRL >/dev/null
+ls output/v5/records/WU/input1.c-H8E66JWPU5WU >/dev/null
+ls output/v5/records/LF/input2.c-1UNY7PC9RPELF >/dev/null
 
 # Check that the record files are identical.
 for record in {input1,input2}/v5/records/*; do

--- a/tests/swiftc/expected.txt
+++ b/tests/swiftc/expected.txt
@@ -1,43 +1,43 @@
 CHECK: ---
 CHECK: # output/v5/units/output.o-{{.+}}
 CHECK: WorkingDirectory: /fake/working/dir
-CHECK: MainFilePath: 
+CHECK: MainFilePath:
 CHECK: OutputFile: output.o
 CHECK: ModuleName: input
 CHECK: IsSystemUnit: 0
 CHECK: IsModuleUnit: 0
 CHECK: IsDebugCompilation: 1
-CHECK: CompilationTarget: x86_64-apple-macosx10.{{.+}}
+CHECK: CompilationTarget: {{x86_64|arm64}}-apple-macosx10.{{.+}}
 CHECK: SysrootPath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.*}}.sdk
 CHECK: ProviderIdentifier: swift
-CHECK: ProviderVersion: 
+CHECK: ProviderVersion:
 CHECK: Dependencies:
 CHECK: 	DependencyKind: Unit
 CHECK: 	IsSystem: 1
-CHECK: 	UnitOrRecordName: x86_64.swiftinterface-{{.+}}
-CHECK: 	FilePath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/lib/swift/Swift.swiftmodule/x86_64.swiftinterface
+CHECK: 	UnitOrRecordName: {{x86_64|arm64e}}-apple-macos.swiftinterface-{{.+}}
+CHECK: 	FilePath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.*}}.sdk/usr/lib/swift/Swift.swiftmodule/{{x86_64|arm64e}}-apple-macos.swiftinterface
 CHECK: 	ModuleName: Swift
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
 CHECK: 	UnitOrRecordName: input.swift-{{.+}}
 CHECK: 	FilePath: /fake/working/dir/input.swift
-CHECK: 	ModuleName: 
+CHECK: 	ModuleName:
 CHECK: ---
-CHECK: # output/v5/units/x86_64.swiftinterface-{{.+}}
+CHECK: # output/v5/units/{{x86_64|arm64e}}-apple-macos.swiftinterface-{{.+}}
 CHECK: WorkingDirectory: /fake/working/dir
-CHECK: MainFilePath: 
-CHECK: OutputFile: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/lib/swift/Swift.swiftmodule/x86_64.swiftinterface
+CHECK: MainFilePath:
+CHECK: OutputFile: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.+}}.sdk/usr/lib/swift/Swift.swiftmodule/{{x86_64|arm64e}}-apple-macos.swiftinterface
 CHECK: ModuleName: Swift
 CHECK: IsSystemUnit: 1
 CHECK: IsModuleUnit: 1
 CHECK: IsDebugCompilation: 1
-CHECK: CompilationTarget: x86_64-apple-macosx10.{{.+}}
+CHECK: CompilationTarget: {{x86_64|arm64}}-apple-macosx10.{{.+}}
 CHECK: SysrootPath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.+}}.sdk
 CHECK: ProviderIdentifier: swift
-CHECK: ProviderVersion: 
+CHECK: ProviderVersion:
 CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 1
-CHECK: 	UnitOrRecordName: x86_64.swiftinterface-{{.+}}
-CHECK: 	FilePath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/lib/swift/Swift.swiftmodule/x86_64.swiftinterface
+CHECK: 	UnitOrRecordName: {{x86_64|arm64e}}-apple-macos.swiftinterface-{{.+}}
+CHECK: 	FilePath: {{.+}}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{.+}}.sdk/usr/lib/swift/Swift.swiftmodule/{{x86_64|arm64e}}-apple-macos.swiftinterface
 CHECK: 	ModuleName: Swift

--- a/validate-index.cpp
+++ b/validate-index.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
       continue;
     }
 
-    const std::vector<std::pair<std::string, std::string>> unitPaths = {
+    const std::vector<std::pair<std::string, llvm::StringRef>> unitPaths = {
         {"MainFilePath", reader->getMainFilePath()},
         {"SysrootPath", reader->getSysrootPath()},
         {"WorkingDirectory", reader->getWorkingDirectory()},


### PR DESCRIPTION
This diff has a few changes that were required to get this working with
Swift 5.5:

- Tests had hardcoded architectures and SDK versions, these had to be
  updated to allow for newer SDKs, and running tests on M1 machines
- The minimum OS version was hardcoded in the tests, but was not passed
  to the compilers, I hardcoded the same version that was previously
  used, give or take, it doesn't really matter for this case, just that
  they're consistent
- The implicit conversion from llvm::StringRef to std::string was
  removed in
  https://github.com/llvm/llvm-project/commit/777180a32b61070a10dd330b4f038bf24e916af1,
  this change now explicitly converts where required. Theoretically
  there might be some performance wins by cleaning this up, but we'd
  need to profile to know for sure
- Record suffixes produced by clang changed, in general I guess these
  don't have to be stable, but they were hardcoded in tests, so this
  updates them to the new values. I verified it's not source file path
  dependent still.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>