### PR TITLE
Allow not having a records directory

### DIFF
--- a/index-import.cpp
+++ b/index-import.cpp
@@ -384,8 +384,10 @@ static bool remapIndex(const Remapper &remapper,
   SmallString<256> outputRecordsDirectory;
   path::append(outputRecordsDirectory, OutputIndexPath, "v5", "records");
 
+  bool recordsDirectoryExists = fs::exists(recordsDirectory);
+
   if (not fs::is_directory(unitDirectory) ||
-      not fs::is_directory(recordsDirectory)) {
+      (recordsDirectoryExists && not fs::is_directory(recordsDirectory))) {
     errs() << "error: invalid index store directory " << InputIndexPath << "\n";
     return false;
   }
@@ -432,8 +434,10 @@ static bool remapIndex(const Remapper &remapper,
 
   // This batch clones records in the entire index. If we're importing
   // individual ouput files we don't want this.
-  if (not cloneRecords(recordsDirectory, InputIndexPath, outputIndexPath)) {
-    success = false;
+  if (recordsDirectoryExists) {
+    if (not cloneRecords(recordsDirectory, InputIndexPath, outputIndexPath)) {
+      success = false;
+    }
   }
 
   // Process and map the entire index directory

--- a/index-import.cpp
+++ b/index-import.cpp
@@ -384,10 +384,7 @@ static bool remapIndex(const Remapper &remapper,
   SmallString<256> outputRecordsDirectory;
   path::append(outputRecordsDirectory, OutputIndexPath, "v5", "records");
 
-  bool recordsDirectoryExists = fs::exists(recordsDirectory);
-
-  if (not fs::is_directory(unitDirectory) ||
-      (recordsDirectoryExists && not fs::is_directory(recordsDirectory))) {
+  if (not fs::is_directory(unitDirectory)) {
     errs() << "error: invalid index store directory " << InputIndexPath << "\n";
     return false;
   }
@@ -434,7 +431,7 @@ static bool remapIndex(const Remapper &remapper,
 
   // This batch clones records in the entire index. If we're importing
   // individual ouput files we don't want this.
-  if (recordsDirectoryExists) {
+  if (fs::exists(recordsDirectory)) {
     if (not cloneRecords(recordsDirectory, InputIndexPath, outputIndexPath)) {
       success = false;
     }


### PR DESCRIPTION
It's valid to not have records (i.e. an empty swift file), and Bazel won't create empty directories when downloading from a remote cache.