### PR TITLE
Update tests for compiler changes

### DIFF
--- a/tests/clang/expected.txt
+++ b/tests/clang/expected.txt
@@ -1,8 +1,8 @@
 CHECK: ---
 CHECK: # output/v5/units/output.c.o-{{.+}}
 CHECK: WorkingDirectory: /fake/working/dir
-CHECK: MainFilePath:
-CHECK: OutputFile: output.c.o
+CHECK: MainFilePath: /fake/working/dir/input.c
+CHECK: OutputFile: /fake/working/dir/output.c.o
 CHECK: ModuleName:
 CHECK: IsSystemUnit: 0
 CHECK: IsModuleUnit: 0
@@ -15,5 +15,5 @@ CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
 CHECK: 	UnitOrRecordName: input.c-50XRP2AC092F
-CHECK: 	FilePath: input.c
+CHECK: 	FilePath: /fake/working/dir/input.c
 CHECK: 	ModuleName:

--- a/tests/multiple/expected.txt
+++ b/tests/multiple/expected.txt
@@ -1,8 +1,8 @@
 CHECK: ---
 CHECK: # output/v5/units/output1.c.o-{{.+}}
 CHECK: WorkingDirectory: /fake/working/dir
-CHECK: MainFilePath:
-CHECK: OutputFile: output1.c.o
+CHECK: MainFilePath: /fake/working/dir/input1.c
+CHECK: OutputFile: /fake/working/dir/output1.c.o
 CHECK: ModuleName:
 CHECK: IsSystemUnit: 0
 CHECK: IsModuleUnit: 0
@@ -15,13 +15,13 @@ CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
 CHECK: 	UnitOrRecordName: input1.c-H8E66JWPU5WU
-CHECK: 	FilePath: input1.c
+CHECK: 	FilePath: /fake/working/dir/input1.c
 CHECK: 	ModuleName:
 CHECK: ---
 CHECK: # output/v5/units/output2.c.o-{{.+}}
 CHECK: WorkingDirectory: /fake/working/dir
-CHECK: MainFilePath:
-CHECK: OutputFile: output2.c.o
+CHECK: MainFilePath: /fake/working/dir/input2.c
+CHECK: OutputFile: /fake/working/dir/output2.c.o
 CHECK: ModuleName:
 CHECK: IsSystemUnit: 0
 CHECK: IsModuleUnit: 0
@@ -34,5 +34,5 @@ CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
 CHECK: 	UnitOrRecordName: input2.c-1UNY7PC9RPELF
-CHECK: 	FilePath: input2.c
+CHECK: 	FilePath: /fake/working/dir/input2.c
 CHECK: 	ModuleName:

--- a/tests/swiftc/expected.txt
+++ b/tests/swiftc/expected.txt
@@ -1,8 +1,8 @@
 CHECK: ---
 CHECK: # output/v5/units/output.o-{{.+}}
 CHECK: WorkingDirectory: /fake/working/dir
-CHECK: MainFilePath:
-CHECK: OutputFile: output.o
+CHECK: MainFilePath: /fake/working/dir/input.swift
+CHECK: OutputFile: /fake/working/dir/output.o
 CHECK: ModuleName: input
 CHECK: IsSystemUnit: 0
 CHECK: IsModuleUnit: 0


### PR DESCRIPTION
Since Xcode 14 / Swift 5.7, some file paths in index units that were
previously stored relatively, are now stored absolutely. Because of this
our remaps have to change to support the new structure. Along with this,
also as of Xcode 14, `swiftc` and `clang` support remapping the paths in
indexes using `-file-prefix-map foo=bar` and `-ffile-prefix-map=foo=bar`
respectively. This can be used to remove the absolute paths entirely
from the produced index data, which then also requires a new set of
remaps to convert back to absolute for Xcode. I've mostly updated the
tests to use this remapping behavior, which everyone should use if
possible, but I left one case with updated paths to show the new
absolute path behavior.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
