### PR TITLE
Replace std::regex with re2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,27 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+set(CMAKE_CXX_STANDARD 17)
 
 if(COMMAND project)
   project(index-import)
 endif()
+
+set(ABSL_PROPAGATE_CXX_STD ON)
+set(ABSL_ENABLE_INSTALL ON)
+include(FetchContent)
+FetchContent_Declare(
+  absl
+  GIT_REPOSITORY "https://github.com/abseil/abseil-cpp.git"
+  GIT_TAG "20230125.3"
+)
+FetchContent_MakeAvailable(absl)
+
+FetchContent_Declare(
+  re2
+  GIT_REPOSITORY "https://github.com/google/re2.git"
+  GIT_TAG "2023-06-02"
+)
+FetchContent_MakeAvailable(re2)
 
 find_package(Clang CONFIG REQUIRED)
 
@@ -16,7 +34,7 @@ function(add_index_executable execname)
   if(NOT LLVM_ENABLE_RTTI)
     target_compile_options("${execname}" PRIVATE -fno-rtti)
   endif()
-  target_link_libraries("${execname}" PRIVATE clangIndexDataStore)
+  target_link_libraries("${execname}" PRIVATE clangIndexDataStore re2::re2)
   target_link_options("${execname}" PRIVATE -dead_strip)
 endfunction()
 


### PR DESCRIPTION
Turns out that regexes were the bottleneck for large imports. This took
our import time from ~9s to ~4s.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>