### PR TITLE
Absolutize paths after remapping

### DIFF
--- a/index-import.cpp
+++ b/index-import.cpp
@@ -84,7 +84,6 @@ public:
 
     SmallString<128> abs(out);
     llvm::sys::fs::make_absolute(this->pwd, abs);
-    llvm::outs() << "resulting path is " << abs << "\n";
     return abs.str().str();
   }
 

--- a/index-import.cpp
+++ b/index-import.cpp
@@ -77,14 +77,15 @@ public:
       }
     }
 
-    StringRef out = output_str.value_or(path::remove_leading_dotslash(input));
-    if (path::is_absolute(out)) {
-      return out.str();
+    StringRef remapped_str =
+        output_str.value_or(path::remove_leading_dotslash(input));
+    if (path::is_absolute(remapped_str)) {
+      return remapped_str.str();
     }
 
-    SmallString<128> abs(out);
-    llvm::sys::fs::make_absolute(this->pwd, abs);
-    return abs.str().str();
+    SmallString<128> absolute(remapped_str);
+    llvm::sys::fs::make_absolute(this->pwd, absolute);
+    return absolute.str().str();
   }
 
   void addRemap(std::shared_ptr<re2::RE2> &pattern,

--- a/index-import.cpp
+++ b/index-import.cpp
@@ -67,23 +67,23 @@ public:
     }
 
     std::string input_str = input.str();
-    std::optional<StringRef> output_str = std::nullopt;
+    std::optional<StringRef> remapped_str = std::nullopt;
     for (const auto &remap : this->_remaps) {
       const auto &pattern = remap.first;
       const auto &replacement = remap.second;
       if (re2::RE2::Replace(&input_str, *pattern, replacement)) {
-        output_str = path::remove_leading_dotslash(StringRef(input_str));
+        remapped_str = path::remove_leading_dotslash(StringRef(input_str));
         break;
       }
     }
 
-    StringRef remapped_str =
-        output_str.value_or(path::remove_leading_dotslash(input));
-    if (path::is_absolute(remapped_str)) {
-      return remapped_str.str();
+    StringRef output_str =
+        remapped_str.value_or(path::remove_leading_dotslash(input));
+    if (path::is_absolute(output_str)) {
+      return output_str.str();
     }
 
-    SmallString<128> absolute(remapped_str);
+    SmallString<128> absolute(output_str);
     llvm::sys::fs::make_absolute(this->pwd, absolute);
     return absolute.str().str();
   }


### PR DESCRIPTION
The index store library requires paths being written are absolute. If we
don't absolutize them then it does. Unfortunately its logic for that
computes the PWD for every single path, which can amount to ~5% of the
total time spent in index-import.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
