### PR TITLE
Resolve symlinks in absolute paths

### DIFF
--- a/index-import.cpp
+++ b/index-import.cpp
@@ -85,6 +85,7 @@ public:
 
     SmallString<128> absolute(output_str);
     llvm::sys::fs::make_absolute(this->pwd, absolute);
+    llvm::sys::fs::real_path(absolute, absolute);
     return absolute.str().str();
   }
 


### PR DESCRIPTION
Now that we're providing the final absolute path for performance
reasons, we also have to resolve symlinks which apparently the library
did as well, otherwise we end up with invalid indexes in bazel because
the file hashes aren't what we expect.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
