### PR TITLE
Only pass -dead_strip link option on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,10 @@ function(add_index_executable execname)
     target_compile_options("${execname}" PRIVATE -fno-rtti)
   endif()
   target_link_libraries("${execname}" PRIVATE clangIndexDataStore re2::re2)
-  target_link_options("${execname}" PRIVATE -dead_strip)
+
+  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_options("${execname}" PRIVATE -dead_strip)
+  endif()
 endfunction()
 
 add_index_executable(index-import)


### PR DESCRIPTION
`-dead_strip` exists on ld64, the macOS linker, but not necessarily on other linkers.

This solves a build warning on Linux:

    clang++: warning: argument unused during compilation: '-dead_strip' [-Wunused-command-line-argument]