### PR TITLE
Use the system re2 library if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,22 +6,31 @@ if(COMMAND project)
   project(index-import)
 endif()
 
-set(ABSL_PROPAGATE_CXX_STD ON)
-set(ABSL_ENABLE_INSTALL ON)
-include(FetchContent)
-FetchContent_Declare(
-  absl
-  GIT_REPOSITORY "https://github.com/abseil/abseil-cpp.git"
-  GIT_TAG "20230125.3"
-)
-FetchContent_MakeAvailable(absl)
+find_package(re2 QUIET)
+if(NOT re2_FOUND)
+  # There's no re2 library available on this system, download and
+  # build it from GitHub.
+  
+  # Abseil is a build requirement for re2.
+  set(ABSL_PROPAGATE_CXX_STD ON)
+  set(ABSL_ENABLE_INSTALL ON)
+  include(FetchContent)
+  FetchContent_Declare(
+    absl
+    GIT_REPOSITORY "https://github.com/abseil/abseil-cpp.git"
+    GIT_TAG "20230125.3"
+  )
+  FetchContent_MakeAvailable(absl)
 
-FetchContent_Declare(
-  re2
-  GIT_REPOSITORY "https://github.com/google/re2.git"
-  GIT_TAG "2023-06-02"
-)
-FetchContent_MakeAvailable(re2)
+  # Download and build a known-good version of re2.
+  FetchContent_Declare(
+    re2
+    GIT_REPOSITORY "https://github.com/google/re2.git"
+    GIT_TAG "2023-06-02"
+  )
+  FetchContent_MakeAvailable(re2)
+endif()
+
 
 find_package(Clang CONFIG REQUIRED)
 


### PR DESCRIPTION
If the user has re2 available as a system package (e.g. re2-devel on Fedora), use that rather than downloading and compiling re2.

Abseil is only required to build re2, so don't bother downloading and building it if re2 is available.

Helps with #118.