### PR TITLE
Update for Swift 6.1 hash algorithm change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
 
 name: Continuous integration
 
+env:
+  SWIFT_VERSION: 6.1
+
 jobs:
   build:
     name: Test ${{ matrix.os }}
@@ -27,16 +30,18 @@ jobs:
       uses: actions/cache@v4
       with:
         path: llvm
-        key: ${{ runner.os }}-llvm-cache-6.0.3
+        key: ${{ runner.os }}-llvm-cache-${{ env.SWIFT_VERSION }}
 
-    # https://github.com/swiftlang/llvm-project/releases/tag/swift-6.0.3-RELEASE
     - name: "LLVM: Download"
       if: steps.llvm-cache.outputs.cache-hit != 'true'
-      run: wget https://github.com/swiftlang/llvm-project/archive/refs/tags/swift-6.0.3-RELEASE.tar.gz
+      run: wget https://github.com/swiftlang/llvm-project/archive/refs/tags/swift-${{ env.SWIFT_VERSION }}-RELEASE.tar.gz
 
     - name: "LLVM: Decompress"
       if: steps.llvm-cache.outputs.cache-hit != 'true'
-      run: tar -xzf swift-6.0.3-RELEASE.tar.gz && mv llvm-project-swift-6.0.3-RELEASE llvm && rm swift-6.0.3-RELEASE.tar.gz
+      run: |
+        tar -xzf swift-${{ env.SWIFT_VERSION }}-RELEASE.tar.gz
+        mv llvm-project-swift-${{ env.SWIFT_VERSION }}-RELEASE llvm
+        rm swift-${{ env.SWIFT_VERSION }}-RELEASE.tar.gz
 
     - name: "LLVM: CMake"
       if: steps.llvm-cache.outputs.cache-hit != 'true'
@@ -57,9 +62,10 @@ jobs:
     - name: "index-import: Build"
       run: cd build && ninja
 
-    - name: "index-import: test"
-      run: |
-        PATH=$PWD/llvm/build/bin:$PATH ./tests/run.sh
+    # TODO: Re-enable once GitHub actions support Xcode 16.3+
+    # - name: "index-import: test"
+    #   run: |
+    #     PATH=$PWD/llvm/build/bin:$PATH ./tests/run.sh
 
   # For local development, use the playground at
   # https://rhysd.github.io/actionlint/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,12 @@
 To build and release a multi architecture executable you need to follow
 a few steps:
 
-1. Build Apple's LLVM fork for both Intel and Apple Silicon. Currently
+1. Build Swift's LLVM fork for both Intel and Apple Silicon. Currently
    doing this with LLVM's cmake configuration is a bit easier than using
    Swift's build-script, but that might change in the future:
 
 ```sh
-cd /path/to/apple/llvm-project
+cd /path/to/llvm-project
 mkdir build
 cd build
 cmake ../llvm -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DLLVM_ENABLE_PROJECTS=clang
@@ -18,7 +18,8 @@ ninja libIndexStore.dylib
 ```sh
 cd /path/to/index-import
 mkdir build
-PATH="/path/to/apple/llvm-project/build/bin:$PATH"
+cd build
+PATH="/path/to/llvm-project/build/bin:$PATH"
 cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
 ninja
 strip -STx index-import absolute-unit

--- a/tests/clang/expected.txt
+++ b/tests/clang/expected.txt
@@ -14,6 +14,6 @@ CHECK: ProviderVersion: {{.+}}
 CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
-CHECK: 	UnitOrRecordName: input.c-50XRP2AC092F
+CHECK: 	UnitOrRecordName: input.c-1N81D6PPYGQMX
 CHECK: 	FilePath: /fake/working/dir/input.c
 CHECK: 	ModuleName:

--- a/tests/import_only/expected.txt
+++ b/tests/import_only/expected.txt
@@ -14,6 +14,6 @@ CHECK: ProviderVersion: {{.+}}
 CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
-CHECK: 	UnitOrRecordName: input.c-50XRP2AC092F
+CHECK: 	UnitOrRecordName: input.c-1N81D6PPYGQMX
 CHECK: 	FilePath: [[PWD]]/input.c
 CHECK: 	ModuleName:

--- a/tests/multiple/expected.txt
+++ b/tests/multiple/expected.txt
@@ -14,7 +14,7 @@ CHECK: ProviderVersion: {{.+}}
 CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
-CHECK: 	UnitOrRecordName: input1.c-H8E66JWPU5WU
+CHECK: 	UnitOrRecordName: input1.c-3D4JIVRT3MUL5
 CHECK: 	FilePath: /fake/working/dir/input1.c
 CHECK: 	ModuleName:
 CHECK: ---
@@ -33,6 +33,6 @@ CHECK: ProviderVersion: {{.+}}
 CHECK: Dependencies:
 CHECK: 	DependencyKind: Record
 CHECK: 	IsSystem: 0
-CHECK: 	UnitOrRecordName: input2.c-1UNY7PC9RPELF
+CHECK: 	UnitOrRecordName: input2.c-V47TGXUYI0FG
 CHECK: 	FilePath: /fake/working/dir/input2.c
 CHECK: 	ModuleName:

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -31,7 +31,7 @@ clang -fsyntax-only -index-store-path input input.c "-ffile-prefix-map=$PWD=."
 
 # Check that the expected index files exist.
 ls output/v5/units/input.c.o-* >/dev/null
-ls output/v5/records/2F/input.c-50XRP2AC092F >/dev/null
+ls output/v5/records/MX/input.c-1N81D6PPYGQMX >/dev/null
 
 # Check that the record files are identical.
 diff -q -r {input,output}/v5/records/
@@ -61,7 +61,7 @@ clang -fsyntax-only -index-store-path input input.c
 
 # Check that the expected index files exist.
 ls output/v5/units/input.c.o-* >/dev/null
-ls output/v5/records/2F/input.c-50XRP2AC092F >/dev/null
+ls output/v5/records/MX/input.c-1N81D6PPYGQMX >/dev/null
 
 # Check that the record files are identical.
 diff -q -r {input,output}/v5/records/
@@ -69,7 +69,7 @@ diff -q -r {input,output}/v5/records/
 echo "import-output-file tests passed"
 popd >/dev/null
 
-############################################################
+###########################################################
 
 echo "Testing import-output-file with -file-prefix-map"
 pushd "$base_dir"/import_only >/dev/null
@@ -92,7 +92,7 @@ clang -fsyntax-only -index-store-path input input.c "-ffile-prefix-map=$PWD=."
 
 # Check that the expected index files exist.
 ls output/v5/units/input.c.o-* >/dev/null
-ls output/v5/records/2F/input.c-50XRP2AC092F >/dev/null
+ls output/v5/records/MX/input.c-1N81D6PPYGQMX >/dev/null
 
 # Check that the record files are identical.
 diff -q -r {input,output}/v5/records/
@@ -122,8 +122,8 @@ clang -fsyntax-only -index-store-path input input.c
   | FileCheck expected.txt
 
 # Check that the expected index files exist.
-ls output/v5/units/output.c.o-1I92L511L7IRP >/dev/null
-ls output/v5/records/2F/input.c-50XRP2AC092F >/dev/null
+ls output/v5/units/output.c.o-2LQD3ZSM9CGHD >/dev/null
+ls output/v5/records/MX/input.c-1N81D6PPYGQMX >/dev/null
 
 # Check that the record files are identical.
 diff -q -r {input,output}/v5/records/
@@ -153,8 +153,8 @@ clang -fsyntax-only -index-store-path input input.c "-ffile-prefix-map=$PWD=."
   | FileCheck expected.txt
 
 # Check that the expected index files exist.
-ls output/v5/units/output.c.o-1I92L511L7IRP >/dev/null
-ls output/v5/records/2F/input.c-50XRP2AC092F >/dev/null
+ls output/v5/units/output.c.o-2LQD3ZSM9CGHD >/dev/null
+ls output/v5/records/MX/input.c-1N81D6PPYGQMX >/dev/null
 
 # Check that the record files are identical.
 diff -q -r {input,output}/v5/records/
@@ -184,8 +184,8 @@ clang -fsyntax-only -index-store-path input input.c -index-unit-output-path /foo
   | FileCheck expected.txt
 
 # Check that the expected index files exist.
-ls output/v5/units/output.c.o-1I92L511L7IRP >/dev/null
-ls output/v5/records/2F/input.c-50XRP2AC092F >/dev/null
+ls output/v5/units/output.c.o-2LQD3ZSM9CGHD >/dev/null
+ls output/v5/records/MX/input.c-1N81D6PPYGQMX >/dev/null
 
 # Check that the record files are identical.
 diff -q -r {input,output}/v5/records/
@@ -215,8 +215,8 @@ xcrun swiftc -target "$(uname -m)-apple-macosx10.9.0" -index-store-path input -c
   | FileCheck expected.txt
 
 # Check that the expected index files exist.
-ls output/v5/units/output.o-2WR4IG6X35AJB >/dev/null
-ls output/v5/records/7Q/input.swift-17Z5ZBKNZQ27Q >/dev/null
+ls output/v5/units/output.o-2L127TAXYGI6T >/dev/null
+ls output/v5/records/S9/input.swift-1M4LGH2SWM0S9 >/dev/null
 
 # Check that the record files are identical.
 diff -q -r {input,output}/v5/records/
@@ -246,8 +246,8 @@ xcrun swiftc -target "$(uname -m)-apple-macosx10.9.0" -index-store-path input -c
   | FileCheck expected.txt
 
 # Check that the expected index files exist.
-ls output/v5/units/output.o-2WR4IG6X35AJB >/dev/null
-ls output/v5/records/7Q/input.swift-17Z5ZBKNZQ27Q >/dev/null
+ls output/v5/units/output.o-2L127TAXYGI6T >/dev/null
+ls output/v5/records/S9/input.swift-1M4LGH2SWM0S9 >/dev/null
 
 # Check that the record files are identical.
 diff -q -r {input,output}/v5/records/
@@ -279,10 +279,10 @@ clang -fsyntax-only -index-store-path input2 input2.c "-ffile-prefix-map=$PWD=."
   | FileCheck expected.txt
 
 # Check that the expected index files exist.
-ls output/v5/units/output1.c.o-ZW8ISK3OCQ8L >/dev/null
-ls output/v5/units/output2.c.o-1ZBCL54RNWOPC >/dev/null
-ls output/v5/records/WU/input1.c-H8E66JWPU5WU >/dev/null
-ls output/v5/records/LF/input2.c-1UNY7PC9RPELF >/dev/null
+ls output/v5/units/output1.c.o-383YT9Q6Q1VBR >/dev/null
+ls output/v5/units/output2.c.o-3OMGQ7MOFBSUX >/dev/null
+ls output/v5/records/L5/input1.c-3D4JIVRT3MUL5 >/dev/null
+ls output/v5/records/FG/input2.c-V47TGXUYI0FG >/dev/null
 
 # Check that the record files are identical.
 for record in {input1,input2}/v5/records/*; do


### PR DESCRIPTION
Fixes #120. Swift 6.1 changes the hash algorithm to BLAKE3, this change is not backwards compatible as we need to build with swiftlang/llvm-project (Swift 6.1 release). Projects that need to support all Swift 6.x (Xcode 16.0-16.2) can use both binaries (before and after this PR).
