### PR TITLE
Update README.md for arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ When building Swift, keep the following in mind:
 Building all of Swift can take a long time, and most of that isn't needed by `index-import`. A faster way to build `index-import`, is to build only `libIndexStore.dylib`. Here are the commands to do just that:
 
 ```sh
-./swift/utils/build-script --release --skip-build --llvm-targets-to-build X86
-ninja -C build/Ninja-ReleaseAssert/llvm-macosx-x86_64 libIndexStore.dylib
+./swift/utils/build-script --release --skip-build --llvm-targets-to-build AArch64
+ninja -C build/Ninja-ReleaseAssert/llvm-macosx-arm64 libIndexStore.dylib
 ```
 
 Once swift (or `libIndexStore.dylib`) has been built, `index-import` can be built as follows. The _key_ step is to update your `PATH` variable to include the llvm `bin/` directory (from the swift-source build directory). This ensures CMake can find all necessary build dependencies.
@@ -91,7 +91,7 @@ Once swift (or `libIndexStore.dylib`) has been built, `index-import` can be buil
 # From the index-import directory
 mkdir build
 cd build
-PATH="path/to/swift-source/build/Ninja-ReleaseAssert/llvm-macosx-x86_64/bin:$PATH"
+PATH="path/to/swift-source/build/Ninja-ReleaseAssert/llvm-macosx-arm64/bin:$PATH"
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
 ninja
 ```


### PR DESCRIPTION
I'm assuming the default for most developers is ARM64 at this point -- let me know if you'd like me to split the instructions into x86 & ARM.