### PR TITLE
Add release logic to CI workflow

### DIFF
--- a/.github/generate-notes.sh
+++ b/.github/generate-notes.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly swift_version=$1
+readonly macos_archive=$2
+
+readonly upstream_url="https://github.com/swiftlang/llvm-project/releases/tag/swift-$swift_version-RELEASE"
+
+macos_sha=$(shasum -a 256 "$macos_archive")
+
+cat <<EOF
+The binary included with this release was built against Swift $swift_version at [this tag]($upstream_url).
+
+sha256:
+\`\`\`
+$macos_sha
+\`\`\`
+EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,14 +79,14 @@ jobs:
       run: |
         PATH=$PWD/llvm/build/bin:$PATH ./tests/run.sh
 
-#     - name: "index-import: archive"
-#       run: |
-#         cd build
-#         COPYFILE_DISABLE=1 tar czvf index-import.tar.gz absolute-unit index-import
+    - name: "index-import: archive"
+      run: |
+        cd build
+        COPYFILE_DISABLE=1 tar czvf index-import.tar.gz absolute-unit index-import
 
-#     - name: "index-import: upload"
-#       uses: actions/upload-artifact@v4
-#       path: build/index-import.tar.gz
+    # - name: "index-import: upload"
+    #   uses: actions/upload-artifact@v4
+    #   path: build/index-import.tar.gz
 
   # create-release:
   #   name: Create release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
     name: Create release
     needs: build
     runs-on: ubuntu-22.04
-    if: github.event_name == 'workflow_dispatch'
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,12 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The new version to tag, ex: 1.0.5'
+        required: true
+        type: string
 
 name: Continuous integration
 
@@ -72,6 +78,39 @@ jobs:
     - name: "index-import: test"
       run: |
         PATH=$PWD/llvm/build/bin:$PATH ./tests/run.sh
+
+    - name: "index-import: archive"
+      run: |
+        cd build
+        COPYFILE_DISABLE=1 tar czvf index-import.tar.gz absolute-unit index-import
+
+    - name: "index-import: upload"
+      uses: actions/upload-artifact@v4
+      path: build/index-import.tar.gz
+
+  create-release:
+    name: Create release
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+
+      - name: Download index-import artifact
+        uses: actions/download-artifact@v4
+
+      - name: Create release
+        run: |
+          set -euo pipefail
+
+          macos_archive="index-import.tar.gz"
+          ./.github/generate-notes.sh "$SWIFT_VERSION" "$macos_archive" | tee notes.md
+          cat notes.md
+          echo "would have called" gh release create "$TAG" --title "$TAG" --target "$GITHUB_REF_NAME" --notes-file notes.md "$macos_archive"
+        env:
+          TAG: ${{ inputs.tag }}
+          SWIFT_VERSION: ${{ env.SWIFT_VERSION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # For local development, use the playground at
   # https://rhysd.github.io/actionlint/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,8 @@ jobs:
 
     - name: "index-import: upload"
       uses: actions/upload-artifact@v4
-      path: build/index-import.tar.gz
+      with:
+        path: build/index-import.tar.gz
 
   # create-release:
   #   name: Create release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,14 +79,14 @@ jobs:
       run: |
         PATH=$PWD/llvm/build/bin:$PATH ./tests/run.sh
 
-    - name: "index-import: archive"
-      run: |
-        cd build
-        COPYFILE_DISABLE=1 tar czvf index-import.tar.gz absolute-unit index-import
+#     - name: "index-import: archive"
+#       run: |
+#         cd build
+#         COPYFILE_DISABLE=1 tar czvf index-import.tar.gz absolute-unit index-import
 
-    - name: "index-import: upload"
-      uses: actions/upload-artifact@v4
-      path: build/index-import.tar.gz
+#     - name: "index-import: upload"
+#       uses: actions/upload-artifact@v4
+#       path: build/index-import.tar.gz
 
   # create-release:
   #   name: Create release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
 
   create-release:
     name: Create release
+    needs: build
     runs-on: ubuntu-22.04
     if: github.event_name == 'workflow_dispatch'
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,9 +84,9 @@ jobs:
         cd build
         COPYFILE_DISABLE=1 tar czvf index-import.tar.gz absolute-unit index-import
 
-    # - name: "index-import: upload"
-    #   uses: actions/upload-artifact@v4
-    #   path: build/index-import.tar.gz
+    - name: "index-import: upload"
+      uses: actions/upload-artifact@v4
+      path: build/index-import.tar.gz
 
   # create-release:
   #   name: Create release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,21 +97,21 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v4
 
-      - name: Download index-import artifact
-        uses: actions/download-artifact@v4
+      # - name: Download index-import artifact
+      #   uses: actions/download-artifact@v4
 
-      - name: Create release
-        run: |
-          set -euo pipefail
+      # - name: Create release
+      #   run: |
+      #     set -euo pipefail
 
-          macos_archive="index-import.tar.gz"
-          ./.github/generate-notes.sh "$SWIFT_VERSION" "$macos_archive" | tee notes.md
-          cat notes.md
-          echo "would have called" gh release create "$TAG" --title "$TAG" --target "$GITHUB_REF_NAME" --notes-file notes.md "$macos_archive"
-        env:
-          TAG: ${{ inputs.tag }}
-          SWIFT_VERSION: ${{ env.SWIFT_VERSION }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     macos_archive="index-import.tar.gz"
+      #     ./.github/generate-notes.sh "$SWIFT_VERSION" "$macos_archive" | tee notes.md
+      #     cat notes.md
+      #     echo "would have called" gh release create "$TAG" --title "$TAG" --target "$GITHUB_REF_NAME" --notes-file notes.md "$macos_archive"
+      #   env:
+      #     TAG: ${{ inputs.tag }}
+      #     SWIFT_VERSION: ${{ env.SWIFT_VERSION }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # For local development, use the playground at
   # https://rhysd.github.io/actionlint/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,14 +88,14 @@ jobs:
       uses: actions/upload-artifact@v4
       path: build/index-import.tar.gz
 
-  create-release:
-    name: Create release
-    needs: build
-    runs-on: ubuntu-22.04
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    steps:
-      - name: Check out source code
-        uses: actions/checkout@v4
+  # create-release:
+  #   name: Create release
+  #   needs: build
+  #   runs-on: ubuntu-22.04
+  #   if: ${{ github.event_name == 'workflow_dispatch' }}
+  #   steps:
+  #     - name: Check out source code
+  #       uses: actions/checkout@v4
 
       # - name: Download index-import artifact
       #   uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,30 +89,30 @@ jobs:
       with:
         path: build/index-import.tar.gz
 
-  # create-release:
-  #   name: Create release
-  #   needs: build
-  #   runs-on: ubuntu-22.04
-  #   if: ${{ github.event_name == 'workflow_dispatch' }}
-  #   steps:
-  #     - name: Check out source code
-  #       uses: actions/checkout@v4
+  create-release:
+    name: Create release
+    needs: build
+    runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
 
-      # - name: Download index-import artifact
-      #   uses: actions/download-artifact@v4
+      - name: Download index-import artifact
+        uses: actions/download-artifact@v4
 
-      # - name: Create release
-      #   run: |
-      #     set -euo pipefail
+      - name: Create release
+        run: |
+          set -euo pipefail
 
-      #     macos_archive="index-import.tar.gz"
-      #     ./.github/generate-notes.sh "$SWIFT_VERSION" "$macos_archive" | tee notes.md
-      #     cat notes.md
-      #     echo "would have called" gh release create "$TAG" --title "$TAG" --target "$GITHUB_REF_NAME" --notes-file notes.md "$macos_archive"
-      #   env:
-      #     TAG: ${{ inputs.tag }}
-      #     SWIFT_VERSION: ${{ env.SWIFT_VERSION }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          macos_archive="index-import.tar.gz"
+          ./.github/generate-notes.sh "$SWIFT_VERSION" "$macos_archive" | tee notes.md
+          cat notes.md
+          echo "would have called" gh release create "$TAG" --title "$TAG" --target "$GITHUB_REF_NAME" --notes-file notes.md "$macos_archive"
+        env:
+          TAG: ${{ inputs.tag }}
+          SWIFT_VERSION: ${{ env.SWIFT_VERSION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # For local development, use the playground at
   # https://rhysd.github.io/actionlint/


### PR DESCRIPTION
This hijacks the existing workflow to also do releases only when
manually dispatched with a tag. Primarily done this way to not duplicate
all logic.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
